### PR TITLE
Fix pervasive syntax errors in OWL Restrictions

### DIFF
--- a/uml/uml.ttl
+++ b/uml/uml.ttl
@@ -77,10 +77,9 @@ uml:upperValue rdf:type owl:ObjectProperty ;
 uml:ValueSpecification rdf:type owl:Class ;
               rdfs:comment "UML 2.5.1 specification section 8" ;
               rdfs:subClassOf sbol:Identified ,
-    # Properties inherited from TypedElement:
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:anyURI ; owl:onProperty uml:type ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
-    # Omitted subclass Expression, OpaqueExpression, TimeExpression, Duration, Interval
+                   # Properties inherited from TypedElement:
+                   [ rdf:type owl:Restriction ; owl:onProperty uml:type ; owl:allValuesFrom xsd:anyURI ] ,
+                   [ rdf:type owl:Restriction ; owl:onProperty uml:type ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:LiteralSpecification rdf:type owl:Class ;
               rdfs:comment "UML 2.5.1 specification section 8.2" ;
@@ -94,8 +93,9 @@ uml:LiteralNull rdf:type owl:Class ;
 uml:LiteralString rdf:type owl:Class ;
               rdfs:comment "UML 2.5.1 specification section 8.2" ;
               rdfs:subClassOf uml:LiteralSpecification ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:string ; owl:onProperty uml:stringValue ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+    [ rdf:type owl:Restriction ; owl:onProperty uml:stringValue ; owl:allValuesFrom xsd:string ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:stringValue ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:stringValue ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:stringValue rdf:type owl:DatatypeProperty ;
          rdfs:domain uml:LiteralString ;
@@ -105,8 +105,9 @@ uml:stringValue rdf:type owl:DatatypeProperty ;
 uml:LiteralInteger rdf:type owl:Class ;
               rdfs:comment "UML 2.5.1 specification section 8.2" ;
               rdfs:subClassOf uml:LiteralSpecification ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:integer ; owl:onProperty uml:integerValue ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:integerValue ; owl:allValuesFrom xsd:integer ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:integerValue ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:integerValue ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:integerValue rdf:type owl:DatatypeProperty ;
          rdfs:domain uml:LiteralInteger ;
@@ -116,8 +117,9 @@ uml:integerValue rdf:type owl:DatatypeProperty ;
 uml:LiteralBoolean rdf:type owl:Class ;
               rdfs:comment "UML 2.5.1 specification section 8.2" ;
               rdfs:subClassOf uml:LiteralSpecification ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:boolean ; owl:onProperty uml:booleanValue ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:booleanValue ; owl:allValuesFrom xsd:boolean ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:booleanValue ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:booleanValue ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:booleanValue rdf:type owl:DatatypeProperty ;
          rdfs:domain uml:LiteralBoolean ;
@@ -127,8 +129,9 @@ uml:booleanValue rdf:type owl:DatatypeProperty ;
 uml:LiteralReal rdf:type owl:Class ;
               rdfs:comment "UML 2.5.1 specification section 8.2" ;
               rdfs:subClassOf uml:LiteralSpecification ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:float ; owl:onProperty uml:realValue ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+        [ rdf:type owl:Restriction ; owl:onProperty uml:realValue ; owl:allValuesFrom xsd:float ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:realValue ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:realValue ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:realValue rdf:type owl:DatatypeProperty ;
          rdfs:domain uml:LiteralReal ;
@@ -138,8 +141,9 @@ uml:realValue rdf:type owl:DatatypeProperty ;
 uml:LiteralIdentified rdf:type owl:Class ;
               rdfs:comment "SBOL-specific class for embedding SBOL object literals as a child object" ;
               rdfs:subClassOf uml:LiteralSpecification ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom sbol:Identified ; owl:onProperty uml:identifiedValue ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:identifiedValue ; owl:allValuesFrom sbol:Identified ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:identifiedValue ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:identifiedValue ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:identifiedValue rdf:type owl:ObjectProperty ;
          rdfs:subPropertyOf opil:compositionalProperty ;
@@ -163,9 +167,10 @@ uml:referenceValue rdf:type owl:ObjectProperty ;
 uml:Constraint rdf:type owl:Class ;
               rdfs:comment "UML 2.5.1 specification section 7.6" ;
               rdfs:subClassOf sbol:Identified ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom sbol:Identified ; owl:onProperty uml:constrainedElement ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ValueSpecification ; owl:onProperty uml:specification ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+        [ rdf:type owl:Restriction ; owl:allValuesFrom sbol:Identified ; owl:onProperty uml:constrainedElement ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:specification ; owl:allValuesFrom uml:ValueSpecification ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:specification ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:specification ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:constrainedElement rdf:type owl:ObjectProperty ;
          rdfs:domain uml:Constraint ;
@@ -183,22 +188,25 @@ uml:specification rdf:type owl:ObjectProperty ;
 uml:Parameter rdf:type owl:Class ;
               rdfs:comment "UML 2.5.1 specification section 9.4" ;
               rdfs:subClassOf sbol:Identified ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:anyURI ; owl:onProperty uml:direction ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ValueSpecification ; owl:onProperty uml:defaultValue  ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:direction ; owl:allValuesFrom xsd:anyURI ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:direction ; owl:minCardinality "1"^^xsd:nonNegativeInteger ],
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:direction ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:defaultValue ; owl:allValuesFrom uml:ValueSpecification ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:defaultValue ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
     # omitted: /default, effect, isException, isStream
     # Properties inherited from MultiplicityElement and TypedElement:
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:anyURI ; owl:onProperty uml:type ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:boolean ; owl:onProperty uml:isOrdered ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:boolean ; owl:onProperty uml:isUnique ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ValueSpecification ; owl:onProperty uml:lowerValue ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ValueSpecification ; owl:onProperty uml:upperValue ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+    [ rdf:type owl:Restriction ; owl:onProperty uml:type ; owl:allValuesFrom xsd:anyURI ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:type ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:isOrdered ; owl:allValuesFrom xsd:boolean ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:isOrdered ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:isOrdered ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:isUnique ; owl:allValuesFrom xsd:boolean ],
+    [ rdf:type owl:Restriction ; owl:onProperty uml:isUnique ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:isUnique ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:lowerValue ; owl:allValuesFrom uml:ValueSpecification ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:lowerValue ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:upperValue ; owl:allValuesFrom uml:ValueSpecification ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:upperValue ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
     # omitted: /lower, /upper
 
 uml:direction rdf:type owl:DatatypeProperty ;
@@ -309,10 +317,10 @@ uml:MergeNode rdf:type owl:Class ;
 uml:DecisionNode rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 15.3" ;
              rdfs:subClassOf uml:ControlNode ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:Behavior ; owl:onProperty uml:decisionInput ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ObjectFlow ; owl:onProperty uml:decisionInputFlow ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+    [ rdf:type owl:Restriction ; owl:onProperty uml:decisionInput ; owl:allValuesFrom uml:Behavior ] ,
+    [ rdf:type owl:Restriction ; owl:onProperty uml:decisionInput ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:decisionInputFlow ; owl:allValuesFrom uml:ObjectFlow ] ,
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:decisionInputFlow ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:decisionInput rdf:type owl:ObjectProperty ;
          rdfs:domain uml:DecisionNode ;
@@ -328,24 +336,26 @@ uml:decisionInputFlow rdf:type owl:ObjectProperty ;
 
 uml:ObjectNode rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 15.4" ;
-             rdfs:subClassOf uml:ActivityNode .
+             rdfs:subClassOf uml:ActivityNode ,
     # omitted subtype: CentralBufferNode, DataStoreNode
     # omitted: isControlType, ordering, selection, upperBound, inState
     # Property inherited from TypedElement:
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:anyURI ; owl:onProperty uml:type ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:type ; owl:allValuesFrom xsd:anyURI ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:type ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+
 
 uml:ActivityParameterNode rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 15.4" ;
-             rdfs:subClassOf uml:ObjectNode .
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:Parameter ; owl:onProperty uml:parameter ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+             rdfs:subClassOf uml:ObjectNode ,
+        [ rdf:type owl:Restriction ; owl:allValuesFrom uml:Parameter ; owl:onProperty uml:parameter ] ,
+        [ rdf:type owl:Restriction ; owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:onProperty uml:parameter ] ,
+        [ rdf:type owl:Restriction ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ; owl:onProperty uml:parameter ] .
+
 
 uml:parameter rdf:type owl:ObjectProperty ;
          rdfs:domain uml:ActivityParameterNode ;
          rdfs:range uml:Parameter ;
          rdfs:label "parameter" .
-
 
 
 uml:ExecutableNode rdf:type owl:Class ;
@@ -391,28 +401,30 @@ uml:CallAction rdf:type owl:Class ;
 uml:CallBehaviorAction rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 16.3" ;
              rdfs:subClassOf uml:CallAction ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:Behavior ; owl:onProperty uml:behavior ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:behavior ; owl:allValuesFrom uml:Behavior ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:behavior ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ;  owl:onProperty uml:behavior ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:behavior rdf:type owl:ObjectProperty ;
          rdfs:domain uml:CallBehaviorAction ;
          rdfs:range uml:Behavior ;
          rdfs:label "behavior" .
 
-
+# starting here
 uml:Pin rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 16.2" ;
              rdfs:subClassOf uml:ObjectNode ,
-    # omitted: isControl
-    # Properties inherited from MultiplicityElement:
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:boolean ; owl:onProperty uml:isOrdered ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom xsd:boolean ; owl:onProperty uml:isUnique ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ValueSpecification ; owl:onProperty uml:lowerValue ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ValueSpecification ; owl:onProperty uml:upperValue ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+             [ rdf:type owl:Restriction ; owl:onProperty uml:isOrdered ; owl:allValuesFrom xsd:boolean ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:isOrdered ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:isOrdered ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:isUnique ; owl:allValuesFrom xsd:boolean ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:isUnique ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:isUnique ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:lowerValue ; owl:allValuesFrom uml:ValueSpecification ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:lowerValue ;  owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:upperValue ; owl:allValuesFrom uml:ValueSpecification ] ,
+        [ rdf:type owl:Restriction ; owl:onProperty uml:upperValue ;  owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+
 
 uml:InputPin rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 16.2" ;
@@ -422,8 +434,9 @@ uml:InputPin rdf:type owl:Class ;
 uml:ValuePin rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 16.2" ;
              rdfs:subClassOf uml:InputPin ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ValueSpecification ; owl:onProperty uml:value ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:value ; owl:allValuesFrom uml:ValueSpecification ] ,
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:value ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:value ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
 
 uml:value rdf:type owl:ObjectProperty ;
          rdfs:subPropertyOf opil:compositionalProperty ;
@@ -440,10 +453,12 @@ uml:OutputPin rdf:type owl:Class ;
 uml:ActivityEdge rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 15.2" ;
              rdfs:subClassOf sbol:Identified ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ActivityNode ; owl:onProperty uml:source ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
-    [ rdf:type owl:Restriction ; owl:allValuesFrom uml:ActivityNode ; owl:onProperty uml:target ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:source ; owl:allValuesFrom uml:ActivityNode ] ,
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:source ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:source ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:target ; owl:allValuesFrom uml:ActivityNode ] ,
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:target ; owl:minCardinality "1"^^xsd:nonNegativeInteger ] ,
+    [ rdf:type owl:Restriction ;  owl:onProperty uml:target ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] .
     # omitted: redefinedEdge, guard, weight
     # Note that guard will need to be added to allow DecisionNode
 

--- a/uml/uml.ttl
+++ b/uml/uml.ttl
@@ -22,8 +22,11 @@
 owl:maxCardinality rdf:type owl:AnnotationProperty .
 owl:minCardinality rdf:type owl:AnnotationProperty .
 
-opil:compositionalProperty rdf:type owl:AnnotationProperty . # should be SBOL - sbol_factory issue #10
+#################################################################
+#    Object properties
+#################################################################
 
+opil:compositionalProperty rdf:type owl:ObjectProperty . # should be SBOL - sbol_factory issue #10
 
 #################################################################
 #    Datatypes
@@ -225,8 +228,6 @@ uml:defaultValue rdf:type owl:ObjectProperty ;
 uml:Behavior rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 13.2" ;
              rdfs:subClassOf sbol:TopLevel ,
-    #[ rdf:type owl:Restriction ; owl:allValuesFrom xsd:boolean ; owl:onProperty uml:isReentrant ;
-    #  owl:minCardinality "1"^^xsd:nonNegativeInteger ; owl:maxCardinality "1"^^xsd:nonNegativeInteger ] ,
     [ rdf:type owl:Restriction ; owl:allValuesFrom uml:Constraint ; owl:onProperty uml:precondition ] ,
     [ rdf:type owl:Restriction ; owl:allValuesFrom uml:Constraint ; owl:onProperty uml:postcondition ] ,
     [ rdf:type owl:Restriction ; owl:allValuesFrom uml:Parameter ; owl:onProperty uml:ownedParameter ] .
@@ -358,6 +359,7 @@ uml:parameter rdf:type owl:ObjectProperty ;
          rdfs:label "parameter" .
 
 
+
 uml:ExecutableNode rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 15.5" ;
              rdfs:subClassOf uml:ActivityNode .
@@ -410,7 +412,7 @@ uml:behavior rdf:type owl:ObjectProperty ;
          rdfs:range uml:Behavior ;
          rdfs:label "behavior" .
 
-# starting here
+
 uml:Pin rdf:type owl:Class ;
              rdfs:comment "UML 2.5.1 specification section 16.2" ;
              rdfs:subClassOf uml:ObjectNode ,


### PR DESCRIPTION
The syntax rule for `owl:Restriction` states:

> The class owl:Restriction is defined as a subclass of owl:Class. A restriction class should have exactly one triple linking the restriction to a particular property, using the owl:onProperty property. The restriction class should also have exactly one triple that represents the value constraint c.q. cardinality constraint on the property under consideration, e.g., that the cardinality of the property is exactly 1. 